### PR TITLE
Some pull requests from forks and umerged PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-#Anything-sync-daemon
+# Anything-sync-daemon
 Anything-sync-daemon (asd) is a tiny pseudo-daemon designed to manage user defined dirs in tmpfs and to periodically sync back to the physical disc (HDD/SSD). This is accomplished via a symlinking step and an innovative use of rsync to maintain back-up and synchronization between the two. One of the major design goals of asd is a completely transparent user experience.
 
-##Documentation
+## Documentation
 Consult the man page or the wiki page: https://wiki.archlinux.org/index.php/Anything-sync-daemon
 
-##Installation from Source
+## Installation from Source
 To build from source, see the included INSTALL text document.
 
-##Installation from Distro Packages
+## Installation from Distro Packages
 * ![logo](http://www.monitorix.org/imgs/archlinux.png "arch logo")Arch: in the [AUR](https://aur.archlinux.org/packages/anything-sync-daemon).
 * ![logo](http://s18.postimg.org/w5jvz71mt/chakra.jpg "chakra logo")Chakra: in the [CCR](http://chakraos.org/ccr/packages.php?ID=3750).
 
-##WARNING
+## WARNING
 Users of versions older than v5.69 MUST stop asd before upgrading. Data loss can occur if you ignore this warning.
 
 Arch Linux users do not need to worry about if asd is installed from the official PKGBUILD in the AUR. This contains a pre_upgrade scriptlet that will stop asd for you.

--- a/init/asd-resync.service
+++ b/init/asd-resync.service
@@ -9,6 +9,12 @@ PartOf=asd.service
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/anything-sync-daemon resync
+OOMScoreAdjust=-1000
+Nice=19
+IOSchedulingClass=idle
+IOSchedulingPriority=7
+CPUSchedulingPolicy=idle
+CPUSchedulingPriority=1
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION

Fix broken Markdown headings
dc26712
Commits on Apr 27, 2017
@graysky2
graysky2
Merge pull request #49 from bryant1410/master

Fix broken headings in Markdown files

6166712
Commits on May 11, 2017
@parcha
parcha
Specify priority & scheduling for systemd service

OOMScoreAdjust is used to disable this service from OOM killer consideration, as this will explicitly be recovering memory.

IO and CPU scheduling (incl. niceness) both reflect the lowest priorities possible, as keeping the data in tmpfs longer helps performance anyway.

In the future, it may be better to dynamically choose the scheduling policies used, depending on memory pressure or integrity requirements.

f9cf210
@parcha
parcha
Merge pull request #1 from parcha/service-prio

Specify priority & scheduling for systemd service